### PR TITLE
fix malformed post content in main language post when saving a sublanguage

### DIFF
--- a/include/admin.php
+++ b/include/admin.php
@@ -327,7 +327,7 @@ class Sublanguage_admin extends Sublanguage_main {
 					$this->sublanguage_data[$this->current_language->ID][$field] = $data[$field];
 					
 					// and restore original data
-					$data[$field] = $post->$field;
+					$data[$field] = wp_slash($post->$field);
 				}
 				
 			}


### PR DESCRIPTION
In Sublanguage_admin::insert_post, the main language post data is loaded from db and restored to post array so WP will save the original main language content.

However, this replaced post data is not escaped (wp_slash/wp_unslash).
Since WP expects to receive escaped data back, when it later calls wp_unslash, the original content is damaged.
(This is especially bad if the post content isn't HTML but is, say, JSON.)