### PR TITLE
Fix #12: use post type translations into default language

### DIFF
--- a/sublanguage.php
+++ b/sublanguage.php
@@ -2321,7 +2321,7 @@ class Sublanguage_main {
 	 */
 	public function translate_custom_post_link($link, $post_id, $sample = false) {
 		
-		if (!$sample && $this->is_sub()) {
+		if (!$sample) {
 			
 			$post = get_post($post_id);
 			


### PR DESCRIPTION
The `is_sub()` check is performed in `translate_post_field()`, so I figured it's not necessary to have it in `translate_custom_post_link()` as well.