### PR TITLE
Custom language var

### DIFF
--- a/include/admin-settings.php
+++ b/include/admin-settings.php
@@ -125,6 +125,14 @@ class Sublanguage_settings {
 		);
 		
 		add_settings_field(	
+			'sublanguage-query-var', 
+			__('Query var name', 'sublanguage'), 
+			array($this, 'field_language_query_var'), 
+			$sublanguage_admin->page_name, 
+			'section-settings'
+		);
+
+		add_settings_field(	
 			'sublanguage-version', 
 			__('Version', 'sublanguage'), 
 			array($this, 'field_version'), 
@@ -336,6 +344,20 @@ class Sublanguage_settings {
 	}
 	
 	/**
+	 *	@from 1.5.5
+	 */
+	function field_language_query_var($args) {
+		global $sublanguage_admin;
+       
+		echo sprintf('<input type="text" name="%s" value="%s"/><br/><label>%s</label>',
+			$sublanguage_admin->option_name.'[language_query_var]',
+			$sublanguage_admin->get_option('language_query_var', 'language'),
+			__('Set the URL parameter that allows language switching.', 'sublanguage')
+		);
+		
+	}
+	
+	/**
 	 *	@from 1.5
 	 */
 	function field_ajax_post_admin($args) {
@@ -453,6 +475,7 @@ class Sublanguage_settings {
 		$output['current_first'] = (isset($input['current_first']) && $input['current_first']);
 		$output['version'] = isset($input['version']) ? esc_attr($input['version']) : '-';
 		$output['ajax_post_admin'] = isset($input['ajax_post_admin']) && $input['ajax_post_admin'] ? 1 : 0;
+		$output['language_query_var'] = !empty($input['language_query_var']) ? esc_attr($input['language_query_var']) : '';
 		
     	return $output;
 	}

--- a/include/admin.php
+++ b/include/admin.php
@@ -32,7 +32,9 @@ class Sublanguage_admin extends Sublanguage_main {
 	 * @from 1.0
 	 */
 	public function __construct() {
-	
+
+		$this->language_query_var = $this->get_option('language_query_var', $this->language_query_var);
+
 		add_action( 'plugins_loaded', array($this, 'load'));
 		
 	}

--- a/include/site.php
+++ b/include/site.php
@@ -17,7 +17,9 @@ class Sublanguage_site extends Sublanguage_main {
 	 * @from 1.0
 	 */
 	public function __construct() {
-		
+
+		$this->language_query_var = $this->get_option('language_query_var', $this->language_query_var);
+
 		$this->detect_language();
 		
 		add_action( 'plugins_loaded', array($this, 'load'));


### PR DESCRIPTION
This PR makes the `language_query_var` property name configurable. This way e.g. if my blog is already using `lng=fr` to translate contents, now I can indicate Sublanguage to use the `lng` as well (instead of the default `language` name).

See https://wordpress.org/support/topic/customize-query-var-name/