### PR TITLE
Allow special characters in cpt archive url

### DIFF
--- a/class-admin-ui.php
+++ b/class-admin-ui.php
@@ -429,7 +429,7 @@ class Sublanguage_admin_ui extends Sublanguage_admin {
 					// custom post type archive
 					if (isset($_POST['cpt_archive'])) {
 
-						$cpt_archive = isset($_POST['cpt_archive']) ? array_map(array($this, 'sanitize_slug'), $_POST['cpt_archive']) : array();
+						$cpt_archive = isset($_POST['cpt_archive']) ?  $_POST['cpt_archive'] : array();
 
 						if (!isset($translations['cpt_archive'][$post_type]) || $translations['cpt_archive'][$post_type] !== $cpt_archive) {
 							$translations['cpt_archive'][$post_type] = $cpt_archive;


### PR DESCRIPTION
Don't do sanitize_slug on cpt archive url

sanitize_slug does urlencode and removes certain characters which are legal for  cpt archive link

"мухи/список"
is a valid url for cpt archive, but your code doesn't accept it

maybe sanitize_text_field() is better for this?

p.s. 
for the post type permalink base a change is also needed - but it does need some filtering (just without urlencode)
