### PR TITLE
Fix broken logic sublanguage_import_post - it didn't work without specifing post_type

### DIFF
--- a/class-admin.php
+++ b/class-admin.php
@@ -1531,23 +1531,25 @@ class Sublanguage_admin extends Sublanguage_rewrite {
 
 		if (isset($post_id, $data['sublanguages'], $data['post_type']) && $this->is_post_type_translatable($data['post_type'])) {
 
-			foreach ($data['sublanguages'] as $sub_data) {
+				foreach ($data['sublanguages'] as $sub_data) {
 
-				if (isset($sub_data['language'])) {
+					if (isset($sub_data['language'])) {
 
-					$sub_data['ID'] = $post_id;
-					$sub_data['post_type'] = $data['post_type'];
-					$sub_data['post_status'] = get_post_field('post_status', $post_id);
+						$sub_data['ID'] = $post_id;
+						$sub_data['post_type'] = $data['post_type'];
+						$sub_data['post_status'] = get_post_field('post_status', $post_id);
 
-					$language = $this->find_language($sub_data['language']);
+						$language = $this->find_language($sub_data['language']);
 
-					if (isset($language)) {
+						if (isset($language)) {
 
-						foreach ($this->fields as $field) {
+							foreach ($this->fields as $field) {
 
-							if (isset($sub_data[$field])) {
+								if (isset($sub_data[$field])) {
 
-								update_post_meta($post_id, $this->create_prefix($language->post_name).$field, $sub_data[$field]);
+									update_post_meta($post_id, $this->create_prefix($language->post_name).$field, $sub_data[$field]);
+
+								}
 
 							}
 
@@ -1556,8 +1558,6 @@ class Sublanguage_admin extends Sublanguage_rewrite {
 					}
 
 				}
-
-			}
 
 		}
 

--- a/class-admin.php
+++ b/class-admin.php
@@ -1488,7 +1488,7 @@ class Sublanguage_admin extends Sublanguage_rewrite {
 	 *
 	 *		@int 	$ID (Optional) post Id
 	 *		@string $post_name (Optional) post name
-	 *		@string $post_type (Optional) post type. Required if ID or post_name is not set
+	 *		@string $post_type (Optional) post type.
 	 *		@string $post_title (Optional) post title
 	 *		@string $post_content (Optional) post content
 	 *		@string $post_status (Optional) post status
@@ -1529,14 +1529,17 @@ class Sublanguage_admin extends Sublanguage_rewrite {
 
 		}
 
-		if (isset($post_id, $data['sublanguages'], $data['post_type']) && $this->is_post_type_translatable($data['post_type'])) {
+		if (isset($post_id, $data['sublanguages'])){
+			$post_type=get_post_type($post_id);
+
+			if ($post_type && $this->is_post_type_translatable($post_type)) {
 
 				foreach ($data['sublanguages'] as $sub_data) {
 
 					if (isset($sub_data['language'])) {
 
 						$sub_data['ID'] = $post_id;
-						$sub_data['post_type'] = $data['post_type'];
+						$sub_data['post_type'] = $post_type;
 						$sub_data['post_status'] = get_post_field('post_status', $post_id);
 
 						$language = $this->find_language($sub_data['language']);
@@ -1559,6 +1562,8 @@ class Sublanguage_admin extends Sublanguage_rewrite {
 
 				}
 
+			}
+			
 		}
 
 	}


### PR DESCRIPTION
Fix broken logic sublanguage_import_post - it didn't work without specifing post_type:
The "This code find an existing post whose ID equals 123 and adds translations for french and italian." example fails (and i fix that).

post_type is optional for creating a new post - it defaults to 'post'

I've added an extra `if` so it caused git to lose track of the changes (and show a lot of changes - most of them are just white space)